### PR TITLE
swap polygon api  url

### DIFF
--- a/src/constants/types.ts
+++ b/src/constants/types.ts
@@ -1,29 +1,7 @@
 export interface PolygonMappedToken {
-  chainId: number
-  child_address_passed_by_user: boolean
-  child_token: string
-  count: number
-  created_at: string
-  decimals: number
-  deleted: boolean
-  id: number
-  map_type: 'POS'
-  mintable: boolean
-  name: string
-  new_child_token: string
-  new_mintable: boolean
-  owner: string
-  reason: string
-  reason_for_remapping: string
-  remapping_allowed: boolean
-  remapping_request_submitted: boolean
-  remapping_verified: boolean
-  root_token: string
-  status: number
-  symbol: string
-  token_type: string // ERC20
-  updated_at: string
-  uri: string
+  rootToken: string
+  childToken: string
+  isPos?: boolean
 }
 
 export type GenericMappedTokenData = { [key: string]: string | undefined }

--- a/src/providers/PolygonMappingProvider.ts
+++ b/src/providers/PolygonMappingProvider.ts
@@ -2,8 +2,9 @@ import axios from 'axios'
 import { MappingProvider } from './MappingProvider'
 import { PolygonMappedTokenData } from '../constants/types'
 
-const url = 'https://tokenmapper.api.matic.today/api/v1/mapping?'
-const params = 'map_type=[%22POS%22]&chain_id=137&limit=200&offset='
+// called from https://mapper.polygon.technology
+const url = 'https://open-api.polygon.technology/api/v1/info/all-mappings'
+const access_token = '504afd90-3228-4df9-9d88-9b4d70646101'
 
 /**
  * The Polygon team manually maintains the mapping via user submissions at
@@ -13,22 +14,15 @@ const params = 'map_type=[%22POS%22]&chain_id=137&limit=200&offset='
  */
 export class PolygonMappingProvider implements MappingProvider {
   async provide(): Promise<PolygonMappedTokenData> {
-    let offset = 0
+    const response = await axios.get(url, {
+      headers: { 'x-access-token': access_token },
+    })
     const tokens: PolygonMappedTokenData = {}
-    while (true) {
-      const response = await axios.get(`${url}${params}${offset}`)
 
-      if (response.data.message === 'success') {
-        for (const token of response.data.data.mapping) {
-          tokens[token.root_token.toLowerCase()] = token
-        }
-
-        if (response.data.data.has_next_page === true) {
-          offset += 200
-          continue
-        }
+    for (const token of response.data) {
+      if (token.isPos) {
+        tokens[token.rootToken.toLowerCase()] = token
       }
-      break
     }
     return tokens
   }

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -182,12 +182,11 @@ async function getChildTokenDetails(
 
     const childTokenAddress = childToken
       ? ethers.utils.getAddress(
-          typeof childToken === 'object' ? childToken.child_token : childToken
+          typeof childToken === 'object' ? childToken.childToken : childToken
         )
       : undefined
     const childTokenValid = Boolean(
       childTokenAddress &&
-        (typeof childToken === 'object' ? !childToken.deleted : true) &&
         (await hasExistingTokenContract(childTokenAddress, chainId))
     )
     return {


### PR DESCRIPTION
The API endpoint which Polygon's mapping [site](https://mapper.polygon.technology/) used seems to have switched. The original one no longer works. Updated the endpoint and token in this PR, based on what gets called when you visit https://mapper.polygon.technology/.