### PR TITLE
swap mainnet rpc url

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ or
 `npm i @uniswap/token-list-bridge-utils`
 
 ### Create .env file (Optional)
-- By default, the library uses `https://cloudflare-eth.com/` as the MAINNET_RPC env variable value required by arbitrum-sdk. You can override this value by creating a .env file in your root directory and setting a value for MAINNET_RPC.
+- By default, the library uses `https://rpc.ankr.com/eth` as the MAINNET_RPC env variable value required by arbitrum-sdk. You can override this value by creating a .env file in your root directory and setting a value for MAINNET_RPC.
 
   - Sample .env file contents:
 

--- a/src/arbitrum/set_rpc.ts
+++ b/src/arbitrum/set_rpc.ts
@@ -2,6 +2,6 @@ import { config } from 'dotenv'
 import { ChainId } from '../constants/chainId'
 import { getRpcUrl } from '../utils'
 
-// MAINNET_RPC value is required for arb-sdk. fall back to https://cloudflare-eth.com/ if MAINNET_RPC not provided in an .env file
+// MAINNET_RPC value is required for arb-sdk. fall back to https://rpc.ankr.com/eth if MAINNET_RPC not provided in an .env file
 config()
 process.env.MAINNET_RPC ??= getRpcUrl(ChainId.MAINNET)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -95,7 +95,7 @@ export const isTokenList = (obj: any) => {
 export function getRpcUrl(chainId: ChainId): string {
   switch (chainId) {
     case ChainId.MAINNET:
-      return 'https://cloudflare-eth.com/'
+      return 'https://rpc.ankr.com/eth'
     case ChainId.OPTIMISM:
       return 'https://rpc.ankr.com/optimism' // seems to have higher rate limit than https://mainnet.optimism.io/
     case ChainId.OPTIMISTIC_KOVAN:


### PR DESCRIPTION
RPC calls to https://cloudflare-eth.com/ are often failing when calling chainify for large lists like the [Uniswap Extended List](https://extendedtokens.uniswap.org/), presumably due to rate limiting at the RPC level. 

Using https://rpc.ankr.com/eth instead seems to work fine. Tested building the extended list locally several times without any errors, so this PR swaps the mainnet RPC url to https://rpc.ankr.com/eth to fix the issue. 