### PR TITLE
feat: create a token map in chainify

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "@tsconfig/recommended": "^1.0.1",
     "@types/jest": "^27.4.1",
     "@types/lodash": "^4.14.179",
-    "@uniswap/token-lists": "^1.0.0-beta.27",
+    "@uniswap/token-lists": "^1.0.0-beta.33",
     "dts-cli": "^1.4.0",
     "husky": "^7.0.4",
     "size-limit": "^7.0.8",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -231,6 +231,93 @@ describe(mergeTokenLists, () => {
   })
 })
 describe(chainify, () => {
+  it('creates tokenMap correctly in chainify', async () => {
+    const chainified = await chainify(sampleL1TokenList)
+
+    expect(chainified.tokenMap).toEqual({
+      '10_0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1': {
+        ...Tokens[ChainId.OPTIMISM]!.DAI,
+        name: 'Dai Stablecoin',
+        extensions: {
+          bridgeInfo: {
+            [ChainId.MAINNET]: {
+              tokenAddress: DAI.address,
+            },
+          },
+        },
+      },
+      '137_0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063': {
+        ...Tokens[ChainId.POLYGON]!.DAI,
+        extensions: {
+          bridgeInfo: {
+            [ChainId.MAINNET]: {
+              tokenAddress: DAI.address,
+            },
+          },
+        },
+      },
+      '1_0x6B175474E89094C44Da98b954EedeAC495271d0F': {
+        ...Tokens[ChainId.MAINNET]!.DAI,
+        extensions: {
+          bridgeInfo: {
+            [ChainId.BNB]: {
+              tokenAddress: DAI_BNB.address,
+            },
+            [ChainId.AVALANCHE]: {
+              tokenAddress: DAI_AVALANCHE.address,
+            },
+            [ChainId.OPTIMISM]: {
+              tokenAddress: DAI_OPTIMISM.address,
+            },
+            [ChainId.POLYGON]: {
+              tokenAddress: DAI_POLYGON.address,
+            },
+            [ChainId.ARBITRUM_ONE]: {
+              tokenAddress: DAI_ARBITRUM_ONE.address,
+              // destBridgeAddress: arbBridgeL2Address,
+              // originBridgeAddress: arbBridgeL1Address,
+            },
+          },
+        },
+      },
+      '42161_0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1': {
+        ...Tokens[ChainId.ARBITRUM_ONE]!.DAI,
+        extensions: {
+          bridgeInfo: {
+            [ChainId.MAINNET]: {
+              tokenAddress: DAI.address,
+              // originBridgeAddress: arbBridgeL2Address,
+              // destBridgeAddress: arbBridgeL1Address,
+            },
+          },
+        },
+        name: 'Dai Stablecoin',
+      },
+      '43114_0xd586E7F844cEa2F87f50152665BCbc2C279D8d70': {
+        ...Tokens[ChainId.AVALANCHE]!.DAI,
+        name: 'Dai Stablecoin',
+        symbol: 'DAI',
+        extensions: {
+          bridgeInfo: {
+            [ChainId.MAINNET]: {
+              tokenAddress: DAI.address,
+            },
+          },
+        },
+      },
+      '56_0x1AF3F329e8BE154074D8769D1FFa4eE058B1DBc3': {
+        ...Tokens[ChainId.BNB]!.DAI,
+        extensions: {
+          bridgeInfo: {
+            [ChainId.MAINNET]: {
+              tokenAddress: DAI.address,
+            },
+          },
+        },
+      },
+    })
+  })
+
   it('provides bridge extensions', async () => {
     const chainified = await chainify(sampleL1TokenList)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,10 +28,18 @@ export async function chainify(
   ]
 
   const chainified = await chainifyTokenList(l2Chains, l1TokenListOrPathOrUrl)
-  return mergeTokenLists(
+  const merged = mergeTokenLists(
     l1TokenList, // providing l1 first to make sure duplicated tokens resolve to this list
     chainified
   )
+
+  const tokenMap = {}
+  if (merged.tokens && merged.tokens.length > 0) {
+    merged.tokens.forEach((token) => {
+      tokenMap[`${token.chainId}_${token.address}`] = token
+    })
+  }
+  return { ...merged, tokenMap }
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -2361,10 +2361,10 @@
     tiny-invariant "^1.1.0"
     toformat "^2.0.0"
 
-"@uniswap/token-lists@^1.0.0-beta.27":
-  version "1.0.0-beta.27"
-  resolved "https://registry.npmjs.org/@uniswap/token-lists/-/token-lists-1.0.0-beta.27.tgz"
-  integrity sha512-x5hmIniQ9TGqOBCRqfWcmZi/U5kB0qrHMDQ9igs3nMbK0wwmYLraL4owbIwXFGR/co6/lJYJC4K/Gjn4wZY5mQ==
+"@uniswap/token-lists@^1.0.0-beta.33":
+  version "1.0.0-beta.33"
+  resolved "https://registry.yarnpkg.com/@uniswap/token-lists/-/token-lists-1.0.0-beta.33.tgz#966ba96c9ccc8f0e9e09809890b438203f2b1911"
+  integrity sha512-JQkXcpRI3jFG8y3/CGC4TS8NkDgcxXaOQuYW8Qdvd6DcDiIyg2vVYCG9igFEzF0G6UvxgHkBKC7cWCgzZNYvQg==
 
 "@yarn-tool/resolve-package@^1.0.40":
   version "1.0.43"


### PR DESCRIPTION
Creates a tokenMap property in the chainify method. For use in downstream repos to easily access specific tokens. Related PR: https://github.com/Uniswap/default-token-list/pull/1620