### PR TITLE
feat: add support for base goerli 

### DIFF
--- a/src/constants/chainId.ts
+++ b/src/constants/chainId.ts
@@ -15,4 +15,6 @@ export enum ChainId {
   BNB = 56,
 
   AVALANCHE = 43114,
+
+  BASE_GOERLI = 84531,
 }

--- a/src/constants/tokens.ts
+++ b/src/constants/tokens.ts
@@ -1,6 +1,30 @@
 import { Token } from '@uniswap/sdk-core'
 import { ChainId } from './chainId'
 
+export const COINBASE_WRAPPED_STAKED_ETH = new Token(
+  ChainId.MAINNET,
+  '0xbe9895146f7af43049ca1c1ae358b0541ea49704',
+  18,
+  'cbETH',
+  'Coinbase Wrapped Staked ETH'
+)
+
+export const COINBASE_WRAPPED_STAKED_ETH_BASE_GOERLI = new Token(
+  ChainId.BASE_GOERLI,
+  '0x7c6b91D9Be155A6Db01f749217d76fF02A7227F2',
+  18,
+  'cbETH',
+  'Coinbase Wrapped Staked ETH'
+)
+
+export const COINBASE_WRAPPED_STAKED_ETH_ARBITRUM_ONE = new Token(
+  ChainId.ARBITRUM_ONE,
+  '0x1DEBd73E752bEaF79865Fd6446b0c970EaE7732f',
+  18,
+  'cbETH',
+  'Coinbase Wrapped Staked ETH'
+)
+
 export const DAI = new Token(
   ChainId.MAINNET,
   '0x6B175474E89094C44Da98b954EedeAC495271d0F',

--- a/src/fixtures/index.ts
+++ b/src/fixtures/index.ts
@@ -10,6 +10,9 @@ import {
   DAI_POLYGON,
   USDT,
   USDT_BNB,
+  COINBASE_WRAPPED_STAKED_ETH,
+  COINBASE_WRAPPED_STAKED_ETH_BASE_GOERLI,
+  COINBASE_WRAPPED_STAKED_ETH_ARBITRUM_ONE,
 } from '../constants/tokens'
 import { compareTokenInfos } from '../utils'
 
@@ -17,9 +20,13 @@ export const Tokens: Partial<Record<ChainId, Record<string, TokenInfo>>> = {
   [ChainId.MAINNET]: {
     DAI: tokenToTokenInfo(DAI),
     USDT: tokenToTokenInfo(USDT),
+    COINBASE_WRAPPED_STAKED_ETH: tokenToTokenInfo(COINBASE_WRAPPED_STAKED_ETH),
   },
   [ChainId.ARBITRUM_ONE]: {
     DAI: tokenToTokenInfo(DAI_ARBITRUM_ONE),
+    COINBASE_WRAPPED_STAKED_ETH: tokenToTokenInfo(
+      COINBASE_WRAPPED_STAKED_ETH_ARBITRUM_ONE
+    ),
   },
   [ChainId.POLYGON]: {
     DAI: tokenToTokenInfo(DAI_POLYGON),
@@ -33,6 +40,11 @@ export const Tokens: Partial<Record<ChainId, Record<string, TokenInfo>>> = {
   },
   [ChainId.AVALANCHE]: {
     DAI: tokenToTokenInfo(DAI_AVALANCHE),
+  },
+  [ChainId.BASE_GOERLI]: {
+    COINBASE_WRAPPED_STAKED_ETH: tokenToTokenInfo(
+      COINBASE_WRAPPED_STAKED_ETH_BASE_GOERLI
+    ),
   },
 }
 
@@ -56,6 +68,17 @@ export const sampleL1TokenList_2: TokenList = {
     patch: 0,
   },
   tokens: [Tokens[ChainId.MAINNET]!.USDT],
+}
+
+export const sampleL1TokenList_3: TokenList = {
+  name: 'Sample_3',
+  timestamp: new Date(1646146610).toISOString(),
+  version: {
+    major: 1,
+    minor: 0,
+    patch: 0,
+  },
+  tokens: [Tokens[ChainId.MAINNET]!.COINBASE_WRAPPED_STAKED_ETH],
 }
 
 export const arbBridgeL2Address = '0x467194771dae2967aef3ecbedd3bf9a310c76c65'
@@ -192,6 +215,34 @@ export const bnbedSampleTokenList_2 = {
         bridgeInfo: {
           [ChainId.BNB]: {
             tokenAddress: USDT_BNB.address,
+          },
+        },
+      },
+    } as unknown as TokenInfo,
+  ].sort(compareTokenInfos),
+}
+
+export const baseGoerliSampleTokenList_3 = {
+  ...sampleL1TokenList_3,
+  name: 'Base Goerli Sample_3',
+  tokens: [
+    {
+      ...Tokens[ChainId.BASE_GOERLI]!.COINBASE_WRAPPED_STAKED_ETH,
+      extensions: {
+        bridgeInfo: {
+          [ChainId.MAINNET]: {
+            tokenAddress: COINBASE_WRAPPED_STAKED_ETH.address,
+          },
+        },
+      },
+    } as unknown as TokenInfo,
+    {
+      ...(Tokens[ChainId.MAINNET]!
+        .COINBASE_WRAPPED_STAKED_ETH as unknown as TokenInfo),
+      extensions: {
+        bridgeInfo: {
+          [ChainId.BASE_GOERLI]: {
+            tokenAddress: COINBASE_WRAPPED_STAKED_ETH_BASE_GOERLI.address,
           },
         },
       },

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -2,6 +2,9 @@ import { TokenInfo } from '@uniswap/token-lists'
 import { chainify, chainifyTokenList, mergeTokenLists } from '.'
 import { ChainId } from './constants/chainId'
 import {
+  COINBASE_WRAPPED_STAKED_ETH,
+  COINBASE_WRAPPED_STAKED_ETH_ARBITRUM_ONE,
+  COINBASE_WRAPPED_STAKED_ETH_BASE_GOERLI,
   DAI,
   DAI_ARBITRUM_ONE,
   DAI_AVALANCHE,
@@ -19,6 +22,8 @@ import {
   sampleL1TokenList_2,
   bnbedSampleTokenList_2,
   avalanchedSampleTokenList,
+  sampleL1TokenList_3,
+  baseGoerliSampleTokenList_3,
 } from './fixtures'
 
 jest.setTimeout(15000)
@@ -129,6 +134,25 @@ it('outputs bnb list correctly with different decimals', async () => {
   ).toEqual(
     // ignores other metadata
     bnbedSampleTokenList_2.tokens.map((t) => [
+      t.address,
+      t.chainId,
+      t.extensions,
+    ])
+  )
+})
+
+it('outputs base goerli list correctly', async () => {
+  const tokenList = await chainifyTokenList(
+    [ChainId.BASE_GOERLI],
+    sampleL1TokenList_3
+  )
+  expect(tokenList).toBeDefined()
+  expect(tokenList?.version).toEqual(baseGoerliSampleTokenList_3.version)
+  expect(
+    tokenList?.tokens.map((t) => [t.address, t.chainId, t.extensions])
+  ).toEqual(
+    // ignores other metadata
+    baseGoerliSampleTokenList_3.tokens.map((t) => [
       t.address,
       t.chainId,
       t.extensions,
@@ -311,6 +335,48 @@ describe(chainify, () => {
           bridgeInfo: {
             [ChainId.MAINNET]: {
               tokenAddress: DAI.address,
+            },
+          },
+        },
+      },
+    ])
+  })
+
+  it('provides bridge extensions for base goerli list', async () => {
+    const chainified = await chainify(sampleL1TokenList_3)
+
+    expect(chainified.tokens).toEqual([
+      {
+        ...Tokens[ChainId.MAINNET]!.COINBASE_WRAPPED_STAKED_ETH,
+        extensions: {
+          bridgeInfo: {
+            [ChainId.ARBITRUM_ONE]: {
+              tokenAddress: COINBASE_WRAPPED_STAKED_ETH_ARBITRUM_ONE.address,
+            },
+            [ChainId.BASE_GOERLI]: {
+              tokenAddress: COINBASE_WRAPPED_STAKED_ETH_BASE_GOERLI.address,
+            },
+          },
+        },
+      },
+      {
+        ...Tokens[ChainId.ARBITRUM_ONE]!.COINBASE_WRAPPED_STAKED_ETH,
+        name: 'Coinbase Wrapped Staked ETH',
+        extensions: {
+          bridgeInfo: {
+            [ChainId.MAINNET]: {
+              tokenAddress: COINBASE_WRAPPED_STAKED_ETH.address,
+            },
+          },
+        },
+      },
+      {
+        ...Tokens[ChainId.BASE_GOERLI]!.COINBASE_WRAPPED_STAKED_ETH,
+        name: 'Coinbase Wrapped Staked ETH',
+        extensions: {
+          bridgeInfo: {
+            [ChainId.MAINNET]: {
+              tokenAddress: COINBASE_WRAPPED_STAKED_ETH.address,
             },
           },
         },

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ export async function chainify(
     ChainId.CELO,
     ChainId.BNB,
     ChainId.AVALANCHE,
+    ChainId.BASE_GOERLI,
   ]
 
   const chainified = await chainifyTokenList(l2Chains, l1TokenListOrPathOrUrl)

--- a/src/providers/BaseGoerliMappingProvider.ts
+++ b/src/providers/BaseGoerliMappingProvider.ts
@@ -1,0 +1,43 @@
+import { MappingProvider } from './MappingProvider'
+import { ChainId } from '../constants/chainId'
+import { getTokenList } from '../utils'
+import { GenericMappedTokenData } from '../constants/types'
+
+const baseGoerliTokenListURL =
+  'https://raw.githubusercontent.com/' +
+  'ethereum-optimism/ethereum-optimism.github.io/master/optimism.tokenlist.json'
+
+/**
+ * The Base Goerli mapping (linked above) is manually maintained by the Coinbase team
+ * in this repository: https://github.com/ethereum-optimism/ethereum-optimism.github.io.
+ */
+export class BaseGoerliMappingProvider implements MappingProvider {
+  async provide(): Promise<GenericMappedTokenData> {
+    const tokens: { [key: string]: string | undefined } = {}
+
+    let allTokens = await getTokenList(baseGoerliTokenListURL)
+
+    let opTokenId_baseGoerliAddressMap = {}
+    allTokens.tokens.forEach((token) => {
+      if (token.chainId === ChainId.BASE_GOERLI) {
+        if (typeof token.extensions?.opTokenId === 'string') {
+          opTokenId_baseGoerliAddressMap[token.extensions.opTokenId] =
+            token.address
+        }
+      }
+    })
+
+    allTokens.tokens.forEach((token) => {
+      if (
+        token.chainId === ChainId.MAINNET &&
+        typeof token.extensions?.opTokenId === 'string' &&
+        token.extensions!.opTokenId in opTokenId_baseGoerliAddressMap
+      ) {
+        tokens[token.address.toLowerCase()] =
+          opTokenId_baseGoerliAddressMap[token.extensions!.opTokenId]
+      }
+    })
+
+    return tokens
+  }
+}

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -21,6 +21,7 @@ import {
   MappedToken,
 } from '../constants/types'
 import { AvalancheMappingProvider } from './AvalancheMappingProvider'
+import { BaseGoerliMappingProvider } from './BaseGoerliMappingProvider'
 
 const web3 = new Web3()
 
@@ -31,6 +32,7 @@ const CHAINS_WITH_MAPPING_PROVIDERS = [
   ChainId.OPTIMISM,
   ChainId.BNB,
   ChainId.AVALANCHE,
+  ChainId.BASE_GOERLI,
 ]
 
 export async function buildList(
@@ -150,6 +152,8 @@ function getMappingProvider(chainId: ChainId, l1TokenList: TokenList) {
       return new BnbMappingProvider()
     case ChainId.AVALANCHE:
       return new AvalancheMappingProvider()
+    case ChainId.BASE_GOERLI:
+      return new BaseGoerliMappingProvider()
     default:
       throw new Error(`Chain ${chainId} not supported for fetching mappings.`)
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -111,7 +111,9 @@ export function getRpcUrl(chainId: ChainId): string {
     case ChainId.BNB:
       return 'https://bsc-dataseed1.binance.org'
     case ChainId.AVALANCHE:
-      return 'https://api.avax.network/ext/bc/C/rpc' 
+      return 'https://api.avax.network/ext/bc/C/rpc'
+    case ChainId.BASE_GOERLI:
+      return 'https://goerli.base.org'
     default:
   }
   throw new Error('Unsupported ChainId')


### PR DESCRIPTION
Add support for base goerli, using tokens maintained by coinbase team in this repo: https://github.com/ethereum-optimism/ethereum-optimism.github.io

FYI I've also reached out to CB to ask them to make sure the mainnet equivalent for each base-goerli token exists in that file (when a mainnet equivalent exists). 