### PR TITLE
fix: update polygon api subdomain

### DIFF
--- a/src/providers/PolygonMappingProvider.ts
+++ b/src/providers/PolygonMappingProvider.ts
@@ -3,7 +3,7 @@ import { MappingProvider } from './MappingProvider'
 import { PolygonMappedTokenData } from '../constants/types'
 
 // called from https://mapper.polygon.technology
-const url = 'https://open-api.polygon.technology/api/v1/info/all-mappings'
+const url = 'https://api-polygon-tokens.polygon.technology/api/v1/info/all-mappings'
 const access_token = '504afd90-3228-4df9-9d88-9b4d70646101'
 
 /**


### PR DESCRIPTION
Polygon seems to have updated their endpoint, moving away from the `open-api` subdomain used [here](https://github.com/Uniswap/token-list-bridge-utils/blob/8257835966dc60d8bf12eb806891a4bb0f993345/src/providers/PolygonMappingProvider.ts) to `api-polygon-tokens`.

The `build` script in the [default-token-list ](https://github.com/Uniswap/default-token-list/blob/11d32203fe89105b1bcea44f01566414da5b1dae/src/buildList.js#L17) will fail as the request will be made towards the old endpoint.

This PR replaces the endpoint, therefore fixing the build issues with token lists.