### PR TITLE
use different eth rpc

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "deduplicate": "yarn-deduplicate --strategy=highest"
   },
   "typings": "dist/index.d.ts",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "dependencies": {
     "@arbitrum/sdk": "^3.1.6",
     "@uniswap/sdk-core": "^4.0.6",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -95,7 +95,7 @@ export const isTokenList = (obj: any) => {
 export function getRpcUrl(chainId: ChainId): string {
   switch (chainId) {
     case ChainId.MAINNET:
-      return 'https://rpc.ankr.com/eth'
+      return 'https://ethereum-rpc.publicnode.com'
     case ChainId.OPTIMISM:
       return 'https://rpc.ankr.com/optimism' // seems to have higher rate limit than https://mainnet.optimism.io/
     case ChainId.OPTIMISTIC_KOVAN:


### PR DESCRIPTION
we are getting errors when rpc calls were attempted to be made for TORN, which is on the unsupported list. This PR uses a different public RPC which does not cause this error. 